### PR TITLE
Increased security for refresh token

### DIFF
--- a/RedditArchiver.py
+++ b/RedditArchiver.py
@@ -59,7 +59,9 @@ def connect():
     """
     Initiates and tests the connection to Reddit.
     """
-    reddit = praw.Reddit(client_id=config['reddit']['client-id'], client_secret=config['reddit']['client-secret'], refresh_token=config['reddit']['refresh-token'], user_agent=f"{__NAME__} v{__VERSION__} by /u/ailothaen")
+    refresh_token_env = os.getenv('refresh_token')
+    refresh_token = refresh_token_env if refresh_token_env is not None else config['reddit']['refresh-token']
+    reddit = praw.Reddit(client_id=config['reddit']['client-id'], client_secret=config['reddit']['client-secret'], refresh_token=refresh_token, user_agent=f"{__NAME__} v{__VERSION__} by /u/ailothaen")
     reddit.auth.scopes()
     return reddit
 


### PR DESCRIPTION
The refresh token can now be specified with an
environment variable, refresh_token, instead of
relying on config.yml.

To use, ' export refresh_token=<user_refresh_token>' followed by 'python3 RedditArchiver.py'.

Note the space before export, this prevents the command from being added to the history, although it will be saved in the current shell's memory.